### PR TITLE
Add route to generate OG images for social media previews

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -15,12 +15,12 @@ const props = defineProps<{
 const { share, isSupported } = useShare()
 
 const link = computed(() => {
-  const url = new URL(window.location.href)
-
-  url.searchParams.set('invoice', props.form.invoice)
-  url.searchParams.set('preimage', props.form.preimage)
-
-  return url.toString()
+  const baseUrl = window.location.origin
+  const hashMode = window.location.hash.startsWith('#')
+  const prefix = hashMode ? '#/' : '/'
+  const invoice = encodeURIComponent(props.form.invoice)
+  const preimage = encodeURIComponent(props.form.preimage)
+  return `${baseUrl}${prefix}${invoice}/${preimage}`
 })
 
 const isDisabled = computed(

--- a/middleware/redirect-query-params.global.ts
+++ b/middleware/redirect-query-params.global.ts
@@ -1,0 +1,9 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if (import.meta.server) return
+
+  if (to.query.invoice && to.query.preimage) {
+    const invoice = encodeURIComponent(to.query.invoice as string)
+    const preimage = encodeURIComponent(to.query.preimage as string)
+    return navigateTo(`/${invoice}/${preimage}`, { replace: true })
+  }
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,22 +1,30 @@
-export default defineNuxtConfig({
-  ssr: false, // SPA mode
+const isSpa = process.env.NUXT_SSR === 'false'
 
-  modules: ['@nuxtjs/tailwindcss', 'nuxt-single-html'],
+export default defineNuxtConfig({
+  ssr: !isSpa,
+
+  modules: ['@nuxtjs/tailwindcss', ...(isSpa ? ['nuxt-single-html'] : [])],
 
   css: ['~/assets/index.css'],
 
+  runtimeConfig: {
+    public: {
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+    },
+  },
+
   router: {
     options: {
-      hashMode: true, // Use hash-based routing for file:// protocol support
+      hashMode: isSpa,
     },
   },
 
   app: {
-    baseURL: './', // Relative base URL for standalone HTML
+    baseURL: isSpa ? './' : '/',
     head: {
       htmlAttrs: {
         lang: '',
-        class: 'dark', // Dark mode by default
+        class: 'dark',
       },
       title: 'Lightning Receipt',
       meta: [
@@ -48,13 +56,19 @@ export default defineNuxtConfig({
 
   typescript: {
     strict: true,
-    typeCheck: false, // Disable for now due to component import issues
+    typeCheck: false,
+  },
+
+  nitro: {
+    rollupConfig: {
+      external: ['@resvg/resvg-js'],
+    },
   },
 
   vite: {
     resolve: {
       alias: {
-        '@': '/src', // Maintain compatibility
+        '@': '/src',
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@noble/secp256k1": "^2.1.0",
+        "@resvg/resvg-js": "^2.6.2",
         "@vee-validate/zod": "^4.14.7",
         "@vueuse/core": "^12.0.0",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "luxon": "^3.5.0",
         "nuxt": "^3.15.3",
         "radix-vue": "^1.9.11",
+        "satori": "^0.19.2",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "vee-validate": "^4.14.7",
@@ -26,7 +28,7 @@
       },
       "devDependencies": {
         "@iconify/vue": "^4.2.0",
-        "@nuxt/devtools": "*",
+        "@nuxt/devtools": "latest",
         "@nuxtjs/tailwindcss": "^6.12.2",
         "@types/jsdom": "^21.1.7",
         "@types/luxon": "^3.4.2",
@@ -36,6 +38,7 @@
         "@vue/eslint-config-typescript": "^14.1.3",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.20",
+        "cross-env": "^10.1.0",
         "cypress": "^13.16.0",
         "eslint": "^9.14.0",
         "eslint-plugin-cypress": "^4.1.0",
@@ -766,6 +769,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -4997,6 +5007,221 @@
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
@@ -5554,6 +5779,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -7576,6 +7817,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -8270,6 +8520,24 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8293,6 +8561,27 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
@@ -8303,6 +8592,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/css-select": {
@@ -8319,6 +8617,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -9018,6 +9327,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -9861,6 +10179,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -10497,6 +10821,18 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hookable": {
@@ -11695,6 +12031,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -13738,6 +14093,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13749,6 +14110,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse5": {
@@ -15568,6 +15939,28 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.19.2.tgz",
+      "integrity": "sha512-71plFHWcq6WJBM5sf/n0eHOmTBiKLUB/G8du7SmLTTLHKEKrV3TPHGKcEVIoyjnbhnjvu9HhLyF9MATB/zzL7g==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -16158,6 +16551,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -16660,6 +17059,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -17070,6 +17475,16 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.0.1.tgz",
       "integrity": "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -19160,6 +19575,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "test:unit": "vitest",
     "test:e2e": "start-server-and-test preview http://localhost:3000 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'nuxt dev' http://localhost:3000 'cypress open --e2e'",
-    "build:standalone": "nuxt generate"
+    "build:standalone": "cross-env NUXT_SSR=false nuxt generate",
+    "build:web": "nuxt build"
   },
   "dependencies": {
     "@noble/secp256k1": "^2.1.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@vee-validate/zod": "^4.14.7",
     "@vueuse/core": "^12.0.0",
     "class-variance-authority": "^0.7.1",
@@ -28,6 +30,7 @@
     "luxon": "^3.5.0",
     "nuxt": "^3.15.3",
     "radix-vue": "^1.9.11",
+    "satori": "^0.19.2",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vee-validate": "^4.14.7",
@@ -45,6 +48,7 @@
     "@vue/eslint-config-typescript": "^14.1.3",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^10.1.0",
     "cypress": "^13.16.0",
     "eslint": "^9.14.0",
     "eslint-plugin-cypress": "^4.1.0",

--- a/pages/[invoice]/[preimage].vue
+++ b/pages/[invoice]/[preimage].vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { computed, watchEffect, ref } from 'vue'
+import { computed, watchEffect, ref, reactive } from 'vue'
 
 import bolt11 from 'light-bolt11-decoder'
-// import { Duration } from 'luxon'
+import type { LightningReceipt } from '~/types/index'
 
 import { Icon } from '@iconify/vue'
 import {
@@ -30,9 +30,42 @@ import Separator from '~/components/ui/separator/Separator.vue'
 const isPaid = ref(false)
 const isVerified = ref(false)
 
-const { form } = useForm()
+const route = useRoute()
+const form = reactive<LightningReceipt>({
+  invoice: (decodeURIComponent(route.params.invoice as string) || '').toLowerCase(),
+  preimage: (decodeURIComponent(route.params.preimage as string) || '').toLowerCase(),
+})
 
 const payeePubKey = ref('')
+
+const requestUrl = useRequestURL()
+const baseUrl = `${requestUrl.protocol}//${requestUrl.host}`
+
+const ogImageUrl = computed(() => {
+  if (!form.invoice || !form.preimage) return ''
+  return `${baseUrl}/api/og/${encodeURIComponent(form.invoice)}/${encodeURIComponent(form.preimage)}`
+})
+
+const pageUrl = computed(() => {
+  if (!form.invoice || !form.preimage) return ''
+  return `${baseUrl}/${encodeURIComponent(form.invoice)}/${encodeURIComponent(form.preimage)}`
+})
+
+if (form.invoice && form.preimage) {
+  useSeoMeta({
+    title: 'Lightning Invoice Receipt',
+    description: 'Cryptographic proof of Lightning Network payment',
+    ogTitle: 'Lightning Invoice Receipt',
+    ogDescription: 'Verify Lightning Network payment with cryptographic proof',
+    ogImage: ogImageUrl.value,
+    ogUrl: pageUrl.value,
+    ogType: 'website',
+    twitterCard: 'summary_large_image',
+    twitterTitle: 'Lightning Invoice Receipt',
+    twitterDescription: 'Verify Lightning Network payment with cryptographic proof',
+    twitterImage: ogImageUrl.value,
+  })
+}
 
 const decodedInvoice = computed(() => {
   if (!form.invoice) return null
@@ -40,9 +73,7 @@ const decodedInvoice = computed(() => {
   try {
     const decoded = bolt11.decode(form.invoice)
 
-    if (!decoded) {
-      return null
-    }
+    if (!decoded) return null
 
     const amount = decoded.sections.find((section) => section.name === 'amount')?.value
     const description =
@@ -50,9 +81,7 @@ const decodedInvoice = computed(() => {
     const paymentHash =
       decoded.sections.find((section) => section.name === 'payment_hash')?.value ?? ''
 
-    if (!amount) {
-      return null
-    }
+    if (!amount) return null
 
     return {
       amount: Math.floor(Number(amount) / 1000),
@@ -77,17 +106,13 @@ watchEffect(async () => {
 
 async function checkPaymentProof() {
   const preimage = form.preimage
-  if (preimage === null) {
-    return false
-  }
+  if (preimage === null) return false
+
   const preimageBytes = new Uint8Array(
     preimage!.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
   )
 
-  // Calculate SHA-256 hash using Web Crypto API
   const hashBuffer = await crypto.subtle.digest('SHA-256', preimageBytes)
-
-  // Convert to hex string
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   const computedHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 

--- a/server/api/og/[invoice]/[preimage].get.ts
+++ b/server/api/og/[invoice]/[preimage].get.ts
@@ -97,14 +97,14 @@ function buildOgLayout(
             },
             children: [
               {
-                type: 'div',
+                type: 'span',
                 props: {
                   style: { fontSize: '44px', marginRight: '16px' },
                   children: '\u26A1',
                 },
               },
               {
-                type: 'div',
+                type: 'span',
                 props: {
                   style: {
                     fontSize: '44px',
@@ -132,12 +132,12 @@ function buildOgLayout(
           type: 'div',
           props: {
             style: {
+              display: 'flex',
               height: '1px',
               backgroundColor: '#2a2420',
               width: '100%',
               marginBottom: '40px',
             },
-            children: [],
           },
         },
         {
@@ -153,50 +153,7 @@ function buildOgLayout(
               buildRow('Amount', amountText, true),
               buildRow('Description', truncateDescription(description)),
               buildRow('Payment Hash', formatHash(paymentHash)),
-              {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                  },
-                  children: [
-                    {
-                      type: 'div',
-                      props: {
-                        style: { fontSize: '22px', color: '#a8a29e' },
-                        children: 'Status',
-                      },
-                    },
-                    {
-                      type: 'div',
-                      props: {
-                        style: {
-                          display: 'flex',
-                          alignItems: 'center',
-                          fontSize: '24px',
-                          fontWeight: 700,
-                          color: statusColor,
-                        },
-                        children: [
-                          {
-                            type: 'div',
-                            props: {
-                              style: { marginRight: '10px', fontSize: '28px' },
-                              children: statusIcon,
-                            },
-                          },
-                          {
-                            type: 'div',
-                            props: { children: statusText },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
+              buildRow('Status', `${statusIcon} ${statusText}`, false, statusColor),
             ],
           },
         },
@@ -204,13 +161,13 @@ function buildOgLayout(
           type: 'div',
           props: {
             style: {
+              display: 'flex',
               height: '1px',
               backgroundColor: '#2a2420',
               width: '100%',
               marginTop: '30px',
               marginBottom: '20px',
             },
-            children: [],
           },
         },
         {
@@ -229,7 +186,7 @@ function buildOgLayout(
   }
 }
 
-function buildRow(label: string, value: string, highlight = false) {
+function buildRow(label: string, value: string, highlight = false, valueColor?: string) {
   return {
     type: 'div',
     props: {
@@ -240,19 +197,19 @@ function buildRow(label: string, value: string, highlight = false) {
       },
       children: [
         {
-          type: 'div',
+          type: 'span',
           props: {
             style: { fontSize: '22px', color: '#a8a29e' },
             children: label,
           },
         },
         {
-          type: 'div',
+          type: 'span',
           props: {
             style: {
               fontSize: highlight ? '28px' : '22px',
               fontWeight: highlight ? 700 : 400,
-              color: highlight ? '#fafaf9' : '#d6d3d1',
+              color: valueColor || (highlight ? '#fafaf9' : '#d6d3d1'),
             },
             children: value,
           },

--- a/server/api/og/[invoice]/[preimage].get.ts
+++ b/server/api/og/[invoice]/[preimage].get.ts
@@ -1,0 +1,306 @@
+import satori from 'satori'
+import { Resvg } from '@resvg/resvg-js'
+import { createHash } from 'node:crypto'
+import bolt11 from 'light-bolt11-decoder'
+
+const GOOGLE_FONT_URL =
+  'https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZhrib2Bg-4.ttf'
+const GOOGLE_FONT_BOLD_URL =
+  'https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuFuYMZhrib2Bg-4.ttf'
+
+let fontRegularCache: ArrayBuffer | null = null
+let fontBoldCache: ArrayBuffer | null = null
+
+async function loadFont(url: string): Promise<ArrayBuffer> {
+  const response = await fetch(url)
+  return response.arrayBuffer()
+}
+
+async function getFonts() {
+  if (!fontRegularCache) {
+    fontRegularCache = await loadFont(GOOGLE_FONT_URL)
+  }
+  if (!fontBoldCache) {
+    fontBoldCache = await loadFont(GOOGLE_FONT_BOLD_URL)
+  }
+  return [
+    { name: 'Inter', data: fontRegularCache, weight: 400 as const, style: 'normal' as const },
+    { name: 'Inter', data: fontBoldCache, weight: 700 as const, style: 'normal' as const },
+  ]
+}
+
+function decodeInvoice(invoice: string) {
+  const decoded = bolt11.decode(invoice)
+  if (!decoded) return null
+
+  const amount = decoded.sections.find((s) => s.name === 'amount')?.value
+  const description = decoded.sections.find((s) => s.name === 'description')?.value ?? 'empty'
+  const paymentHash = decoded.sections.find((s) => s.name === 'payment_hash')?.value ?? ''
+
+  if (!amount) return null
+
+  return {
+    amount: Math.floor(Number(amount) / 1000),
+    description,
+    paymentHash,
+  }
+}
+
+function verifyPreimage(preimage: string, paymentHash: string): boolean {
+  const preimageBuffer = Buffer.from(preimage, 'hex')
+  const hash = createHash('sha256').update(preimageBuffer).digest('hex')
+  return hash === paymentHash
+}
+
+function formatHash(text: string): string {
+  const long = text.replace(/\s+/g, '').toUpperCase().slice(Math.max(0, text.length - 16))
+  return `0x${long}`
+}
+
+function truncateDescription(text: string, maxLength = 50): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '...'
+}
+
+function buildOgLayout(
+  amount: number,
+  description: string,
+  paymentHash: string,
+  isPaid: boolean,
+) {
+  const statusColor = isPaid ? '#22c55e' : '#ef4444'
+  const statusText = isPaid ? 'Payment successful!' : 'Invalid preimage'
+  const statusIcon = isPaid ? '\u2713' : '\u2717'
+  const amountText = `${amount.toLocaleString()} ${amount === 1 ? 'sat' : 'sats'}`
+
+  return {
+    type: 'div',
+    props: {
+      style: {
+        width: '1200px',
+        height: '630px',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#1a1412',
+        color: '#fafaf9',
+        fontFamily: 'Inter',
+        padding: '60px',
+      },
+      children: [
+        {
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex',
+              alignItems: 'center',
+              marginBottom: '10px',
+            },
+            children: [
+              {
+                type: 'div',
+                props: {
+                  style: { fontSize: '44px', marginRight: '16px' },
+                  children: '\u26A1',
+                },
+              },
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    fontSize: '44px',
+                    fontWeight: 700,
+                    color: '#e5730a',
+                  },
+                  children: 'Lightning Receipt',
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              fontSize: '18px',
+              color: '#a8a29e',
+              marginBottom: '40px',
+            },
+            children: 'Cryptographic proof of Lightning Network payment',
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              height: '1px',
+              backgroundColor: '#2a2420',
+              width: '100%',
+              marginBottom: '40px',
+            },
+            children: [],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '20px',
+              flex: '1',
+            },
+            children: [
+              buildRow('Amount', amountText, true),
+              buildRow('Description', truncateDescription(description)),
+              buildRow('Payment Hash', formatHash(paymentHash)),
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  },
+                  children: [
+                    {
+                      type: 'div',
+                      props: {
+                        style: { fontSize: '22px', color: '#a8a29e' },
+                        children: 'Status',
+                      },
+                    },
+                    {
+                      type: 'div',
+                      props: {
+                        style: {
+                          display: 'flex',
+                          alignItems: 'center',
+                          fontSize: '24px',
+                          fontWeight: 700,
+                          color: statusColor,
+                        },
+                        children: [
+                          {
+                            type: 'div',
+                            props: {
+                              style: { marginRight: '10px', fontSize: '28px' },
+                              children: statusIcon,
+                            },
+                          },
+                          {
+                            type: 'div',
+                            props: { children: statusText },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              height: '1px',
+              backgroundColor: '#2a2420',
+              width: '100%',
+              marginTop: '30px',
+              marginBottom: '20px',
+            },
+            children: [],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              fontSize: '18px',
+              color: '#78716c',
+              textAlign: 'right',
+            },
+            children: 'lnreceipt',
+          },
+        },
+      ],
+    },
+  }
+}
+
+function buildRow(label: string, value: string, highlight = false) {
+  return {
+    type: 'div',
+    props: {
+      style: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      },
+      children: [
+        {
+          type: 'div',
+          props: {
+            style: { fontSize: '22px', color: '#a8a29e' },
+            children: label,
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              fontSize: highlight ? '28px' : '22px',
+              fontWeight: highlight ? 700 : 400,
+              color: highlight ? '#fafaf9' : '#d6d3d1',
+            },
+            children: value,
+          },
+        },
+      ],
+    },
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const invoice = decodeURIComponent(getRouterParam(event, 'invoice') || '')
+  const preimage = decodeURIComponent(getRouterParam(event, 'preimage') || '')
+
+  if (!invoice || !preimage) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing invoice or preimage' })
+  }
+
+  try {
+    const decoded = decodeInvoice(invoice)
+    if (!decoded) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid invoice' })
+    }
+
+    const isPaid = verifyPreimage(preimage, decoded.paymentHash)
+    const layout = buildOgLayout(decoded.amount, decoded.description, decoded.paymentHash, isPaid)
+    const fonts = await getFonts()
+
+    const svg = await satori(layout, {
+      width: 1200,
+      height: 630,
+      fonts,
+    })
+
+    const resvg = new Resvg(svg, {
+      fitTo: { mode: 'width', value: 1200 },
+    })
+    const pngData = resvg.render()
+    const pngBuffer = pngData.asPng()
+
+    setResponseHeader(event, 'Content-Type', 'image/png')
+    setResponseHeader(event, 'Cache-Control', 'public, max-age=31536000, immutable')
+
+    return pngBuffer
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+    console.error('OG image generation failed:', error)
+    throw createError({ statusCode: 500, statusMessage: 'Failed to generate OG image' })
+  }
+})


### PR DESCRIPTION
## Summary

- Add a server API route (`/api/og/:invoice/:preimage`) that generates a 1200x630 PNG preview image using `satori` + `@resvg/resvg-js`, showing invoice amount, description, payment hash, and verification status
- Add a dynamic receipt page (`/:invoice/:preimage`) with SSR-rendered OG meta tags (`og:image`, `og:title`, `twitter:card`, etc.) so social media crawlers can read them
- Enable conditional SSR: web deployment uses SSR (for OG support), standalone build remains SPA with hash routing (`NUXT_SSR=false`)
- Add middleware to redirect old query-param URLs (`?invoice=...&preimage=...`) to the new route-based format
- Update ShareButton to generate route-based links (auto-detects hash mode for standalone)

## Changes

| File | What changed |
|---|---|
| `nuxt.config.ts` | Conditional SSR, runtimeConfig, nitro externals |
| `server/api/og/[invoice]/[preimage].get.ts` | **New** - OG image generation endpoint |
| `pages/[invoice]/[preimage].vue` | **New** - Receipt page with SSR OG meta tags |
| `middleware/redirect-query-params.global.ts` | **New** - Backward-compat redirect |
| `components/ShareButton.vue` | Route-based link generation |
| `pages/index.vue` | Guard against empty invoice during SSR |
| `package.json` | Added `build:web` script, `satori`, `@resvg/resvg-js`, `cross-env` |

## How it works

- **Web deployment** (`npm run build:web`): SSR renders OG meta tags in HTML. `/api/og/:invoice/:preimage` generates preview images dynamically.
- **Standalone** (`npm run build:standalone`): Works exactly as before (SPA, hash routing, offline). No OG features since there's no server.

## Test plan

- [ ] Verify home page (`/`) renders correctly with SSR
- [ ] Paste invoice + preimage in the form, confirm receipt displays properly
- [ ] Visit `/:invoice/:preimage` and verify OG meta tags in page source
- [ ] Visit `/api/og/:invoice/:preimage` and verify PNG image is generated
- [ ] Test Share button generates correct URL format
- [ ] Test old query-param URLs redirect to new route format
- [ ] Verify standalone build still works with `NUXT_SSR=false`

Closes #8 