### PR TITLE
Add copy link button next to share button

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { LightningReceipt } from '~/types/index'
 
 import { Icon } from '@iconify/vue'
-import { useShare } from '@vueuse/core'
+import { useShare, useClipboard } from '@vueuse/core'
 
 import { Button } from '~/components/ui/button'
 
@@ -12,19 +12,21 @@ const props = defineProps<{
   form: LightningReceipt
 }>()
 
-const { share, isSupported } = useShare()
+const { share, isSupported: isShareSupported } = useShare()
+const { copy, isSupported: isCopySupported } = useClipboard()
+
+const copied = ref(false)
+let copiedTimeout: ReturnType<typeof setTimeout> | null = null
 
 const link = computed(() => {
   const url = new URL(window.location.href)
-
   url.searchParams.set('invoice', props.form.invoice)
   url.searchParams.set('preimage', props.form.preimage)
-
   return url.toString()
 })
 
-const isDisabled = computed(
-  () => isSupported && !(props.form.invoice === '' || props.form.preimage === ''),
+const hasFormData = computed(
+  () => props.form.invoice !== '' && props.form.preimage !== '',
 )
 
 function startShare() {
@@ -34,10 +36,25 @@ function startShare() {
     url: link.value,
   })
 }
+
+function copyLink() {
+  copy(link.value)
+  copied.value = true
+  if (copiedTimeout) clearTimeout(copiedTimeout)
+  copiedTimeout = setTimeout(() => {
+    copied.value = false
+  }, 2000)
+}
 </script>
 
 <template>
-  <Button v-if="isDisabled" @click.prevent="startShare" variant="secondary">
-    <Icon icon="lucide:share-2" /> Share
-  </Button>
+  <div v-if="hasFormData" class="flex items-center gap-2">
+    <Button v-if="isCopySupported" @click.prevent="copyLink" variant="secondary">
+      <Icon :icon="copied ? 'lucide:check' : 'lucide:link'" />
+      {{ copied ? 'Copied!' : 'Copy Link' }}
+    </Button>
+    <Button v-if="isShareSupported" @click.prevent="startShare" variant="secondary">
+      <Icon icon="lucide:share-2" /> Share
+    </Button>
+  </div>
 </template>


### PR DESCRIPTION
### Summary
- Added a "Copy Link" button next to the existing Share button in the receipt footer
- On macOS Safari, the OS share modal doesn't show a "Copy Link" option even when enabled in settings ([known Apple issue](https://discussions.apple.com/thread/252923714))
- The new button uses the Clipboard API to copy the receipt URL directly, bypassing the OS share modal entirely
- Shows "Copied!" feedback with a checkmark icon for 2 seconds after clicking

### Test plan
- [x] Open the app and fill in an invoice + preimage
- [x] Verify the "Copy Link" button appears next to the "Share" button
- [x] Click "Copy Link" and verify the URL is copied to clipboard
- [x] Verify the button text changes to "Copied!" with a checkmark, then reverts after 2 seconds
- [x] Verify the "Share" button still works as before
- [x] Test on macOS Safari to confirm the copy link workaround works

### Closed: #12 