### PR TITLE
Add BOLT12 invoice decoding support 

### DIFF
--- a/composables/invoice.ts
+++ b/composables/invoice.ts
@@ -1,0 +1,73 @@
+import bolt11 from 'light-bolt11-decoder'
+import BOLT12Decoder from 'bolt12-decoder'
+import type { DecodedInvoice as Bolt11DecodedInvoice } from 'light-bolt11-decoder'
+
+export type InvoiceFormat = 'bolt11' | 'bolt12'
+
+export interface DecodedInvoiceResult {
+  format: InvoiceFormat
+  amount: number
+  description: string
+  paymentHash: string
+  payeePubKey: string | null
+  bolt11Raw: Bolt11DecodedInvoice | null
+}
+
+function detectFormat(invoice: string): InvoiceFormat {
+  const lower = invoice.toLowerCase().trim()
+  if (lower.startsWith('lni1') || lower.startsWith('lno1') || lower.startsWith('lnr1')) {
+    return 'bolt12'
+  }
+  return 'bolt11'
+}
+
+function decodeBolt11Invoice(invoice: string): DecodedInvoiceResult | null {
+  const decoded = bolt11.decode(invoice)
+  if (!decoded) return null
+
+  const amount = decoded.sections.find((s) => s.name === 'amount')?.value
+  const description =
+    decoded.sections.find((s) => s.name === 'description')?.value ?? 'empty'
+  const paymentHash =
+    decoded.sections.find((s) => s.name === 'payment_hash')?.value ?? ''
+
+  if (!amount) return null
+
+  return {
+    format: 'bolt11',
+    amount: Math.floor(Number(amount) / 1000),
+    description,
+    paymentHash,
+    payeePubKey: null,
+    bolt11Raw: decoded,
+  }
+}
+
+function decodeBolt12Invoice(invoice: string): DecodedInvoiceResult | null {
+  const decoded = BOLT12Decoder.decode(invoice)
+
+  if (decoded.type === 'offer' || decoded.type === 'invoice_request') {
+    throw new Error(
+      `BOLT12 ${decoded.type === 'offer' ? 'offers' : 'invoice requests'} cannot be verified. Please use a BOLT12 invoice (starts with lni1).`,
+    )
+  }
+
+  if (decoded.type !== 'invoice' || !decoded.paymentHash) return null
+
+  return {
+    format: 'bolt12',
+    amount: decoded.amount ? Math.floor(Number(decoded.amount) / 1000) : 0,
+    description: decoded.description ?? decoded.payerNote ?? 'empty',
+    paymentHash: decoded.paymentHash,
+    payeePubKey: decoded.nodeId ?? null,
+    bolt11Raw: null,
+  }
+}
+
+export function decodeInvoice(invoice: string): DecodedInvoiceResult | null {
+  if (!invoice) return null
+
+  const format = detectFormat(invoice)
+  if (format === 'bolt12') return decodeBolt12Invoice(invoice)
+  return decodeBolt11Invoice(invoice)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/secp256k1": "^2.1.0",
         "@vee-validate/zod": "^4.14.7",
         "@vueuse/core": "^12.0.0",
+        "bolt12-decoder": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "light-bolt11-decoder": "^3.2.0",
@@ -26,7 +27,7 @@
       },
       "devDependencies": {
         "@iconify/vue": "^4.2.0",
-        "@nuxt/devtools": "*",
+        "@nuxt/devtools": "latest",
         "@nuxtjs/tailwindcss": "^6.12.2",
         "@types/jsdom": "^21.1.7",
         "@types/luxon": "^3.4.2",
@@ -1824,6 +1825,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/secp256k1": {
@@ -7252,6 +7265,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7295,6 +7314,44 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bolt12-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bolt12-decoder/-/bolt12-decoder-1.0.0.tgz",
+      "integrity": "sha512-G0nLHvRplv26RkW6sG/7BgWZNiJjVArCvpIarO64yiJcLwfoQMA713VU6QVtzcQoWvG55+bXKDXH+0iP/4zENA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.5.0",
+        "bech32": "^2.0.0",
+        "buffer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/bolt12-decoder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -16937,7 +16994,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@noble/secp256k1": "^2.1.0",
     "@vee-validate/zod": "^4.14.7",
     "@vueuse/core": "^12.0.0",
+    "bolt12-decoder": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "light-bolt11-decoder": "^3.2.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, watchEffect, ref } from 'vue'
 
-import bolt11 from 'light-bolt11-decoder'
-// import { Duration } from 'luxon'
+import { decodeInvoice } from '~/composables/invoice'
 
 import { Icon } from '@iconify/vue'
 import {
@@ -29,47 +28,37 @@ import Separator from '~/components/ui/separator/Separator.vue'
 
 const isPaid = ref(false)
 const isVerified = ref(false)
+const decodeError = ref('')
 
 const { form } = useForm()
 
 const payeePubKey = ref('')
 
 const decodedInvoice = computed(() => {
+  decodeError.value = ''
+  if (!form.invoice) return null
+
   try {
-    const decoded = bolt11.decode(form.invoice)
-
-    if (!decoded) {
-      return null
-    }
-
-    const amount = decoded.sections.find((section) => section.name === 'amount')?.value
-    const description =
-      decoded.sections.find((section) => section.name === 'description')?.value ?? 'empty'
-    const paymentHash =
-      decoded.sections.find((section) => section.name === 'payment_hash')?.value ?? ''
-
-    if (!amount) {
-      return null
-    }
-
-    return {
-      amount: Math.floor(Number(amount) / 1000),
-      description,
-      paymentHash,
-      decoded,
-    }
+    return decodeInvoice(form.invoice)
   } catch (error) {
-    console.error(error)
+    decodeError.value = error instanceof Error ? error.message : 'Invalid invoice'
     return null
   }
 })
 
 watchEffect(async () => {
   isVerified.value = false
+  payeePubKey.value = ''
   if (decodedInvoice.value) {
     isPaid.value = await checkPaymentProof()
     isVerified.value = true
-    payeePubKey.value = (await getPubkeyFromSignature(decodedInvoice.value.decoded)) || ''
+
+    if (decodedInvoice.value.payeePubKey) {
+      payeePubKey.value = decodedInvoice.value.payeePubKey
+    } else if (decodedInvoice.value.bolt11Raw) {
+      payeePubKey.value =
+        (await getPubkeyFromSignature(decodedInvoice.value.bolt11Raw)) || ''
+    }
   }
 })
 
@@ -106,7 +95,7 @@ function formatLong(text: string) {
         <CardDescription class="text-xs">
           <p>
             The provided preimage cryptographically proves that the specified invoice has been
-            successfully paid.
+            successfully paid. Supports both BOLT11 and BOLT12 invoices.
           </p>
           <p>
             Learn more
@@ -123,9 +112,10 @@ function formatLong(text: string) {
         <Separator />
         <div class="font-medium mb-2 mt-5">Invoice:</div>
         <div class="flex w-full items-center">
-          <Input id="invoice" type="text" placeholder="bolt11" v-model="form.invoice" />
+          <Input id="invoice" type="text" placeholder="bolt11 or bolt12 invoice" v-model="form.invoice" />
           <CopyButton title="invoice" :value="form.invoice" />
         </div>
+        <p v-if="decodeError" class="text-sm text-destructive mt-2">{{ decodeError }}</p>
         <div class="font-medium mb-2 mt-5">Payment Proof:</div>
         <div class="flex w-full items-center">
           <Input id="preimage" type="text" placeholder="preimage" v-model="form.preimage" />
@@ -142,6 +132,14 @@ function formatLong(text: string) {
               </TableRow>
             </TableHeader>
             <TableBody>
+              <TableRow>
+                <TableCell class="font-medium"> Format </TableCell>
+                <TableCell class="text-right">
+                  <Badge variant="secondary">
+                    {{ decodedInvoice.format === 'bolt12' ? 'BOLT12' : 'BOLT11' }}
+                  </Badge>
+                </TableCell>
+              </TableRow>
               <TableRow>
                 <TableCell class="font-medium"> Amount </TableCell>
                 <TableCell class="text-right">


### PR DESCRIPTION


### Summary
- Added BOLT12 invoice decoding alongside existing BOLT11 support using `bolt12-decoder` library
- Auto-detects invoice format by prefix (`lnbc` = BOLT11, `lni1` = BOLT12 invoice)
- Shows a format badge (BOLT11/BOLT12) in the invoice details table
- BOLT12 payee public key (`nodeId`) is extracted directly without signature recovery
- Displays a helpful error when a BOLT12 offer (`lno1`) or invoice request (`lnr1`) is entered, since those cannot be verified with a preimage
- Preimage verification (SHA-256 hash comparison) works identically for both formats
- No changes to `composables/utils.ts` or any component files — existing BOLT11 behavior is fully preserved

### Files changed
- `composables/invoice.ts` — **new** unified decoder for BOLT11 and BOLT12
- `pages/index.vue` — uses new decoder, updated placeholder and description text
- `package.json` — added `bolt12-decoder` dependency

### Test plan
- [x] Enter a BOLT11 invoice + preimage — verify it decodes and shows "BOLT11" badge
- [x] Enter a BOLT12 invoice (`lni1...`) + preimage — verify it decodes and shows "BOLT12" badge
- [x] Enter a BOLT12 offer (`lno1...`) — verify error message appears
- [x] Enter a BOLT12 invoice request (`lnr1...`) — verify error message appears
- [x] Verify preimage verification works for both BOLT11 and BOLT12 invoices
- [x] Verify payee pub key is shown for both formats
- [x] Verify Share and Copy Link buttons still work

### Closed: #7 