### PR TITLE
fix: Add Copy Link button for native share fallback

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 import type { LightningReceipt } from '~/types/index'
 
 import { Icon } from '@iconify/vue'
-import { useShare } from '@vueuse/core'
+import { useShare, useClipboard } from '@vueuse/core'
 
 import { Button } from '~/components/ui/button'
 
@@ -12,7 +12,8 @@ const props = defineProps<{
   form: LightningReceipt
 }>()
 
-const { share, isSupported } = useShare()
+const { share, isSupported: isShareSupported } = useShare()
+const { copy, isSupported: isClipboardSupported } = useClipboard()
 
 const link = computed(() => {
   const url = new URL(window.location.href)
@@ -24,7 +25,7 @@ const link = computed(() => {
 })
 
 const isDisabled = computed(
-  () => isSupported && !(props.form.invoice === '' || props.form.preimage === ''),
+  () => !(props.form.invoice === '' || props.form.preimage === ''),
 )
 
 function startShare() {
@@ -34,10 +35,30 @@ function startShare() {
     url: link.value,
   })
 }
+
+function copyLink() {
+  copy(link.value)
+}
 </script>
 
 <template>
-  <Button v-if="isDisabled" @click.prevent="startShare" variant="secondary">
-    <Icon icon="lucide:share-2" /> Share
-  </Button>
+  <div class="flex gap-2">
+    <!-- Native Share Button (if supported) -->
+    <Button 
+      v-if="isShareSupported && isDisabled" 
+      @click.prevent="startShare" 
+      variant="secondary"
+    >
+      <Icon icon="lucide:share-2" /> Share
+    </Button>
+    
+    <!-- Copy Link Button (always available) -->
+    <Button 
+      v-if="isClipboardSupported && isDisabled" 
+      @click.prevent="copyLink" 
+      variant="outline"
+    >
+      <Icon icon="lucide:copy" /> Copy Link
+    </Button>
+  </div>
 </template>


### PR DESCRIPTION
## 🐛 Fix: Copy Link Button Not Showing

Fixes #12

### Problem
Native share API (navigator.share) doesn't always show a "Copy Link" option on some browsers/platforms.

### Solution
Added an independent **"Copy Link"** button that:
- Uses Clipboard API (navigator.clipboard) directly
- Works as a fallback when native share doesn't provide copy option
- Shows alongside the Share button when both are supported

### Changes
- Modified: `components/ShareButton.vue`
- Uses @vueuse/core useClipboard composable
- Maintains backward compatibility

### Testing
- ✅ Tested on browsers where native share doesn't show copy option
- ✅ Copy Link button appears and functions correctly

Ready for review! 🙏