### PR TITLE
fix: Add copy link button for macOS share issue

### DIFF
--- a/components/CopyLinkButton.vue
+++ b/components/CopyLinkButton.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import type { LightningReceipt } from '~/types/index'
+
+import { Icon } from '@iconify/vue'
+import { useClipboard } from '@vueuse/core'
+
+import { Button } from '~/components/ui/button'
+
+const props = defineProps<{
+  form: LightningReceipt
+}>()
+
+const { copy, isSupported } = useClipboard()
+const copied = ref(false)
+
+const link = computed(() => {
+  const url = new URL(window.location.href)
+
+  url.searchParams.set('invoice', props.form.invoice)
+  url.searchParams.set('preimage', props.form.preimage)
+
+  return url.toString()
+})
+
+const isDisabled = computed(
+  () => props.form.invoice === '' || props.form.preimage === '',
+)
+
+function copyLink() {
+  copy(link.value)
+  copied.value = true
+  
+  setTimeout(() => {
+    copied.value = false
+  }, 2000)
+}
+</script>
+
+<template>
+  <Button 
+    v-if="isSupported" 
+    :disabled="isDisabled"
+    @click.prevent="copyLink" 
+    variant="outline"
+  >
+    <Icon :icon="copied ? 'lucide:check' : 'lucide:link'" />
+    {{ copied ? 'Copied!' : 'Copy Link' }}
+  </Button>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,6 +16,7 @@ import {
 import { Input } from '~/components/ui/input'
 import CopyButton from '~/components/CopyButton.vue'
 import ShareButton from '~/components/ShareButton.vue'
+import CopyLinkButton from '~/components/CopyLinkButton.vue'
 
 import {
   Table,
@@ -188,7 +189,8 @@ function formatLong(text: string) {
           </Table>
         </div>
       </CardContent>
-      <CardFooter class="flex justify-center px-6 pb-6">
+      <CardFooter class="flex justify-center gap-3 px-6 pb-6">
+        <CopyLinkButton :form="form" />
         <ShareButton :form="form" />
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Problem
On macOS, the Share button opens the system share dialog but doesn't include a "Copy Link" option, making it difficult for users to copy the receipt URL.

## Solution
Added a dedicated "Copy Link" button next to the Share button that:
- Uses `navigator.clipboard.writeText()` to copy the receipt URL
- Shows visual feedback ("Copied!" with checkmark icon for 2 seconds)
- Follows the existing UI patterns (uses @vueuse/core like CopyButton)
- Placed in CardFooter with proper spacing

## Changes
- Created `components/CopyLinkButton.vue` component
- Updated `pages/index.vue` to include the new button
- Button is disabled when invoice or preimage is empty

Fixes #12