### PR TITLE
Add explicit copy-link fallback next to Share button

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 import type { LightningReceipt } from '~/types/index'
 
 import { Icon } from '@iconify/vue'
-import { useShare } from '@vueuse/core'
+import { useClipboard, useShare } from '@vueuse/core'
 
 import { Button } from '~/components/ui/button'
 
@@ -12,9 +12,14 @@ const props = defineProps<{
   form: LightningReceipt
 }>()
 
-const { share, isSupported } = useShare()
+const { share, isSupported: isShareSupported } = useShare()
+const { copy, isSupported: isClipboardSupported } = useClipboard()
 
 const link = computed(() => {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
   const url = new URL(window.location.href)
 
   url.searchParams.set('invoice', props.form.invoice)
@@ -23,21 +28,39 @@ const link = computed(() => {
   return url.toString()
 })
 
-const isDisabled = computed(
-  () => isSupported && !(props.form.invoice === '' || props.form.preimage === ''),
-)
+const hasRequiredFields = computed(() => props.form.invoice !== '' && props.form.preimage !== '')
+const canShare = computed(() => isShareSupported.value && hasRequiredFields.value)
+const canCopy = computed(() => isClipboardSupported.value && hasRequiredFields.value)
 
 function startShare() {
+  if (!canShare.value) {
+    return
+  }
+
   share({
     title: 'Lightning Receipt',
     text: `Your invoice is paid. Here is the receipt:`,
     url: link.value,
   })
 }
+
+function copyLink() {
+  if (!canCopy.value) {
+    return
+  }
+
+  copy(link.value)
+}
 </script>
 
 <template>
-  <Button v-if="isDisabled" @click.prevent="startShare" variant="secondary">
-    <Icon icon="lucide:share-2" /> Share
-  </Button>
+  <div class="flex items-center gap-2">
+    <Button v-if="canShare" @click.prevent="startShare" variant="secondary">
+      <Icon icon="lucide:share-2" /> Share
+    </Button>
+
+    <Button v-if="canCopy" @click.prevent="copyLink" variant="secondary">
+      <Icon icon="lucide:copy" /> Copy link
+    </Button>
+  </div>
 </template>


### PR DESCRIPTION
## Summary
- add a dedicated **Copy link** button alongside the Share button
- keep native Share flow unchanged for supported platforms
- gate both actions on required receipt fields and capability checks
- make link generation SSR-safe before using `window`

## Why
Issue #12 reports that native share modals on macOS may omit copy-link actions. This adds a deterministic copy path in-app.

## Validation
- npm ci
- npm run type-check
- npm run build

Fixes #12