### PR TITLE
feat: add OG preview route for shared receipts

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -7,6 +7,7 @@ import { Icon } from '@iconify/vue'
 import { useShare } from '@vueuse/core'
 
 import { Button } from '~/components/ui/button'
+import { buildReceiptShareUrl } from '~/composables/utils'
 
 const props = defineProps<{
   form: LightningReceipt
@@ -15,16 +16,11 @@ const props = defineProps<{
 const { share, isSupported } = useShare()
 
 const link = computed(() => {
-  const url = new URL(window.location.href)
-
-  url.searchParams.set('invoice', props.form.invoice)
-  url.searchParams.set('preimage', props.form.preimage)
-
-  return url.toString()
+  return buildReceiptShareUrl(window.location.origin, props.form.invoice, props.form.preimage)
 })
 
 const isDisabled = computed(
-  () => isSupported && !(props.form.invoice === '' || props.form.preimage === ''),
+  () => isSupported.value && !(props.form.invoice === '' || props.form.preimage === ''),
 )
 
 function startShare() {

--- a/composables/utils.test.ts
+++ b/composables/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildReceiptShareUrl } from './utils'
+
+describe('buildReceiptShareUrl', () => {
+  it('builds a share route with encoded invoice and preimage', () => {
+    const url = buildReceiptShareUrl(
+      'https://lnreceipt.example',
+      'lnbc1pjabcde1...',
+      '00ff11aa',
+    )
+
+    expect(url).toBe('https://lnreceipt.example/r/lnbc1pjabcde1.../00ff11aa')
+  })
+
+  it('trims trailing slashes from origin', () => {
+    const url = buildReceiptShareUrl('https://lnreceipt.example///', 'abc', 'def')
+
+    expect(url).toBe('https://lnreceipt.example/r/abc/def')
+  })
+
+  it('encodes reserved URL characters', () => {
+    const url = buildReceiptShareUrl('https://lnreceipt.example', 'lnbc1+abc/def', 'aa/bb+cc')
+
+    expect(url).toBe('https://lnreceipt.example/r/lnbc1%2Babc%2Fdef/aa%2Fbb%2Bcc')
+  })
+})

--- a/composables/utils.ts
+++ b/composables/utils.ts
@@ -13,6 +13,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function buildReceiptShareUrl(origin: string, invoice: string, preimage: string) {
+  const normalizedOrigin = origin.replace(/\/+$/, '')
+  return `${normalizedOrigin}/r/${encodeURIComponent(invoice)}/${encodeURIComponent(preimage)}`
+}
+
 export function useCopyToClipboard(title: string, value: string) {
   const { copy, isSupported } = useClipboard()
   // const { toast } = useToast()

--- a/server/routes/api/og/[invoice]/[preimage].svg.ts
+++ b/server/routes/api/og/[invoice]/[preimage].svg.ts
@@ -1,0 +1,156 @@
+import { createHash } from 'node:crypto'
+import bolt11 from 'light-bolt11-decoder'
+
+type InvoiceSummary = {
+  amountSats: number | null
+  description: string
+  paymentHash: string
+}
+
+function decodeParam(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function isHexString(value: string) {
+  return value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value)
+}
+
+function verifyPreimage(paymentHash: string, preimage: string) {
+  if (!paymentHash || !preimage || !isHexString(preimage)) {
+    return null
+  }
+
+  const computedHash = createHash('sha256')
+    .update(Buffer.from(preimage, 'hex'))
+    .digest('hex')
+
+  return computedHash === paymentHash
+}
+
+function summarizeInvoice(invoice: string): InvoiceSummary {
+  try {
+    const decoded = bolt11.decode(invoice.toLowerCase())
+    const amountValue = decoded.sections.find((section) => section.name === 'amount')?.value
+    const description =
+      decoded.sections.find((section) => section.name === 'description')?.value ?? 'No description'
+    const paymentHash =
+      decoded.sections.find((section) => section.name === 'payment_hash')?.value ?? ''
+
+    const amountMsat = Number(amountValue)
+    const amountSats = Number.isFinite(amountMsat) ? Math.floor(amountMsat / 1000) : null
+
+    return {
+      amountSats,
+      description: String(description),
+      paymentHash: String(paymentHash),
+    }
+  } catch {
+    return {
+      amountSats: null,
+      description: 'Invalid invoice',
+      paymentHash: '',
+    }
+  }
+}
+
+function escapeXml(value: string) {
+  return value.replace(/[<>&'"]/g, (char) => {
+    switch (char) {
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '&':
+        return '&amp;'
+      case "'":
+        return '&apos;'
+      case '"':
+        return '&quot;'
+      default:
+        return char
+    }
+  })
+}
+
+function truncate(value: string, max: number) {
+  if (value.length <= max) {
+    return value
+  }
+  return `${value.slice(0, max - 3)}...`
+}
+
+export default defineEventHandler((event) => {
+  const invoiceParam = getRouterParam(event, 'invoice') ?? ''
+  const preimageParam = getRouterParam(event, 'preimage') ?? ''
+
+  const invoice = decodeParam(invoiceParam).toLowerCase()
+  const preimage = decodeParam(preimageParam).toLowerCase()
+  const summary = summarizeInvoice(invoice)
+  const preimageCheck = verifyPreimage(summary.paymentHash, preimage)
+
+  let statusLabel = 'Status unavailable'
+  let statusColor = '#f59e0b'
+  if (preimageCheck === true) {
+    statusLabel = 'Payment verified'
+    statusColor = '#22c55e'
+  } else if (preimageCheck === false) {
+    statusLabel = 'Invalid preimage'
+    statusColor = '#ef4444'
+  } else if (!summary.paymentHash) {
+    statusLabel = 'Invalid invoice'
+    statusColor = '#ef4444'
+  }
+
+  const amountLabel =
+    summary.amountSats === null
+      ? 'Unknown amount'
+      : `${summary.amountSats} ${summary.amountSats === 1 ? 'sat' : 'sats'}`
+
+  const paymentHashLabel = summary.paymentHash
+    ? `0x${summary.paymentHash.toUpperCase().slice(-16)}`
+    : 'N/A'
+
+  const svg = `
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .bg { fill: #09090b; }
+      .card { fill: #18181b; stroke: #27272a; stroke-width: 1; }
+      .title { fill: #ffffff; font-size: 56px; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; font-weight: 700; }
+      .label { fill: #a1a1aa; font-size: 24px; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+      .value { fill: #ffffff; font-size: 32px; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; font-weight: 600; }
+      .amount { fill: #ffffff; font-size: 40px; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; font-weight: 700; }
+      .mono { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="630" class="bg"/>
+  <rect x="100" y="80" width="1000" height="470" rx="24" class="card"/>
+
+  <text x="148" y="160" class="title">Lightning Receipt</text>
+
+  <text x="148" y="230" class="label">Payment Hash</text>
+  <text x="148" y="270" class="value mono">${escapeXml(paymentHashLabel)}</text>
+
+  <text x="148" y="330" class="label">Amount</text>
+  <text x="148" y="375" class="amount">${escapeXml(amountLabel)}</text>
+
+  <text x="600" y="230" class="label">Description</text>
+  <text x="600" y="270" class="value">${escapeXml(truncate(summary.description, 48))}</text>
+
+  <text x="600" y="330" class="label">Status</text>
+  <text x="600" y="370" class="value" fill="${statusColor}">${escapeXml(statusLabel)}</text>
+</svg>
+`
+
+  setResponseHeaders(event, {
+    'Content-Type': 'image/svg+xml; charset=utf-8',
+    'Cache-Control': 'public, max-age=300',
+  })
+
+  return svg
+})

--- a/server/routes/r/[invoice]/[preimage].ts
+++ b/server/routes/r/[invoice]/[preimage].ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto'
+import bolt11 from 'light-bolt11-decoder'
+
+function decodeParam(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function isHexString(value: string) {
+  return value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value)
+}
+
+function verifyPreimage(paymentHash: string, preimage: string) {
+  if (!paymentHash || !preimage || !isHexString(preimage)) {
+    return null
+  }
+
+  const computedHash = createHash('sha256')
+    .update(Buffer.from(preimage, 'hex'))
+    .digest('hex')
+
+  return computedHash === paymentHash
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[<>&'"]/g, (char) => {
+    switch (char) {
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '&':
+        return '&amp;'
+      case "'":
+        return '&#39;'
+      case '"':
+        return '&quot;'
+      default:
+        return char
+    }
+  })
+}
+
+function truncate(value: string, max: number) {
+  if (value.length <= max) {
+    return value
+  }
+  return `${value.slice(0, max - 3)}...`
+}
+
+export default defineEventHandler((event) => {
+  const requestUrl = getRequestURL(event)
+  const origin = requestUrl.origin
+
+  const invoiceParam = getRouterParam(event, 'invoice') ?? ''
+  const preimageParam = getRouterParam(event, 'preimage') ?? ''
+
+  const invoice = decodeParam(invoiceParam).toLowerCase()
+  const preimage = decodeParam(preimageParam).toLowerCase()
+
+  let amountSats: number | null = null
+  let description = 'Lightning payment receipt'
+  let paymentHash = ''
+
+  try {
+    const decoded = bolt11.decode(invoice)
+    const amountValue = decoded.sections.find((section) => section.name === 'amount')?.value
+    const decodedDescription = decoded.sections.find((section) => section.name === 'description')?.value
+    const decodedHash = decoded.sections.find((section) => section.name === 'payment_hash')?.value
+
+    const amountMsat = Number(amountValue)
+    amountSats = Number.isFinite(amountMsat) ? Math.floor(amountMsat / 1000) : null
+    description = decodedDescription ? String(decodedDescription) : description
+    paymentHash = decodedHash ? String(decodedHash) : ''
+  } catch {
+    description = 'Invalid invoice'
+  }
+
+  const preimageCheck = verifyPreimage(paymentHash, preimage)
+  const status =
+    preimageCheck === true
+      ? 'Payment verified'
+      : preimageCheck === false
+        ? 'Invalid preimage'
+        : paymentHash
+          ? 'Verification pending'
+          : 'Invalid invoice'
+
+  const amountLabel =
+    amountSats === null ? 'Unknown amount' : `${amountSats} ${amountSats === 1 ? 'sat' : 'sats'}`
+
+  const title = amountSats === null ? 'Lightning Receipt' : `Lightning Receipt • ${amountLabel}`
+  const metaDescription = `${status}. ${truncate(description, 96)}`
+
+  const encodedInvoice = encodeURIComponent(invoice)
+  const encodedPreimage = encodeURIComponent(preimage)
+
+  const shareUrl = `${origin}/r/${encodedInvoice}/${encodedPreimage}`
+  const appUrl = `${origin}/?invoice=${encodedInvoice}&preimage=${encodedPreimage}`
+  const ogImageUrl = `${origin}/api/og/${encodedInvoice}/${encodedPreimage}.svg`
+
+  setResponseHeaders(event, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'public, max-age=300',
+  })
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)}</title>
+    <meta name="description" content="${escapeHtml(metaDescription)}" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="${escapeHtml(title)}" />
+    <meta property="og:description" content="${escapeHtml(metaDescription)}" />
+    <meta property="og:url" content="${escapeHtml(shareUrl)}" />
+    <meta property="og:image" content="${escapeHtml(ogImageUrl)}" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="${escapeHtml(title)}" />
+    <meta name="twitter:description" content="${escapeHtml(metaDescription)}" />
+    <meta name="twitter:image" content="${escapeHtml(ogImageUrl)}" />
+    <meta http-equiv="refresh" content="0;url=${escapeHtml(appUrl)}" />
+
+    <script>
+      window.location.replace(${JSON.stringify(appUrl)});
+    </script>
+  </head>
+  <body>
+    Redirecting to receipt...
+    <a href="${escapeHtml(appUrl)}">Open receipt</a>
+  </body>
+</html>
+`
+})


### PR DESCRIPTION
## Summary
- switch share links to a stable route (`/r/:invoice/:preimage`) built for social crawlers
- add a server-rendered share route that emits Open Graph/Twitter meta tags and redirects users to the existing app flow
- add an OG image endpoint at `/api/og/:invoice/:preimage.svg` with invoice amount/description/status rendering
- add unit coverage for share URL generation and encoding behavior

## Validation
- npm run test:unit
- npm run build

Closes #8
