### PR TITLE
feat: add BOLT12 invoice decoding support

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -8,7 +8,7 @@ import { version } from './package.json'
     <NuxtPage />
     <div class="flex-1"></div>
     <div class="text-center">
-      <p>v{{ version }} | made by <a href="https://jaonoctus.dev" target="_blank" class="font-medium text-primary">jaonoctus</a> with <a href="https://vuejs.org" target="_blank" class="font-medium text-primary">Vue.js</a>, <a href="https://www.npmjs.com/package/light-bolt11-decoder" target="_blank" class="font-medium text-primary">bolt11</a> and <span class="font-medium text-red-400">love</span>.</p>
+      <p>v{{ version }} | made by <a href="https://jaonoctus.dev" target="_blank" class="font-medium text-primary">jaonoctus</a> with <a href="https://vuejs.org" target="_blank" class="font-medium text-primary">Vue.js</a>, <a href="https://www.npmjs.com/package/light-bolt11-decoder" target="_blank" class="font-medium text-primary">bolt11</a>, <a href="https://www.npmjs.com/package/bolt12-decoder" target="_blank" class="font-medium text-primary">bolt12</a> and <span class="font-medium text-red-400">love</span>.</p>
       <p>You can download the <a href="https://github.com/jaonoctus/lnreceipt/releases" target="_blank" class="font-medium text-primary underline">lnreceipt-standalone.html</a> offline version from the latest GitHub release</p>
     </div>
   </div>

--- a/composables/invoice.test.ts
+++ b/composables/invoice.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockBolt11Decode, mockBolt12Decode } = vi.hoisted(() => ({
+  mockBolt11Decode: vi.fn(),
+  mockBolt12Decode: vi.fn(),
+}))
+
+vi.mock('light-bolt11-decoder', () => ({
+  default: { decode: mockBolt11Decode },
+}))
+
+vi.mock('bolt12-decoder', () => ({
+  default: { decode: mockBolt12Decode },
+}))
+
+import { decodeInvoice } from './invoice'
+
+describe('decodeInvoice', () => {
+  beforeEach(() => {
+    mockBolt11Decode.mockReset()
+    mockBolt12Decode.mockReset()
+  })
+
+  it('decodes BOLT11 invoices', () => {
+    mockBolt11Decode.mockReturnValue({
+      sections: [
+        { name: 'amount', value: '21000' },
+        { name: 'description', value: 'coffee' },
+        { name: 'payment_hash', value: 'deadbeef' },
+      ],
+    })
+
+    const result = decodeInvoice('lnbc1test')
+
+    expect(result).toEqual({
+      format: 'bolt11',
+      amount: 21,
+      description: 'coffee',
+      paymentHash: 'deadbeef',
+      payeePubKey: null,
+      bolt11Raw: {
+        sections: [
+          { name: 'amount', value: '21000' },
+          { name: 'description', value: 'coffee' },
+          { name: 'payment_hash', value: 'deadbeef' },
+        ],
+      },
+    })
+    expect(mockBolt11Decode).toHaveBeenCalledWith('lnbc1test')
+    expect(mockBolt12Decode).not.toHaveBeenCalled()
+  })
+
+  it('decodes BOLT12 invoices', () => {
+    mockBolt12Decode.mockReturnValue({
+      type: 'invoice',
+      amount: '15000',
+      description: 'tip',
+      paymentHash: 'cafebabe',
+      nodeId: '02abc',
+    })
+
+    const result = decodeInvoice('lni1exampleinvoice')
+
+    expect(result).toEqual({
+      format: 'bolt12',
+      amount: 15,
+      description: 'tip',
+      paymentHash: 'cafebabe',
+      payeePubKey: '02abc',
+      bolt11Raw: null,
+    })
+    expect(mockBolt12Decode).toHaveBeenCalledWith('lni1exampleinvoice')
+    expect(mockBolt11Decode).not.toHaveBeenCalled()
+  })
+
+  it('rejects BOLT12 offers because they cannot be verified by preimage', () => {
+    mockBolt12Decode.mockReturnValue({
+      type: 'offer',
+      description: 'tips',
+    })
+
+    expect(() => decodeInvoice('lno1offer')).toThrow(
+      'BOLT12 offers cannot be verified with a payment preimage. Use a BOLT12 invoice (lni1...).',
+    )
+  })
+
+  it('rejects BOLT12 invoice requests because they cannot be verified by preimage', () => {
+    mockBolt12Decode.mockReturnValue({
+      type: 'invoice_request',
+      amount: '15000',
+    })
+
+    expect(() => decodeInvoice('lnr1request')).toThrow(
+      'BOLT12 invoice requests cannot be verified with a payment preimage. Use a BOLT12 invoice (lni1...).',
+    )
+  })
+
+  it('returns null for empty input', () => {
+    expect(decodeInvoice('')).toBeNull()
+    expect(mockBolt11Decode).not.toHaveBeenCalled()
+    expect(mockBolt12Decode).not.toHaveBeenCalled()
+  })
+})

--- a/composables/invoice.ts
+++ b/composables/invoice.ts
@@ -1,0 +1,102 @@
+import bolt11 from 'light-bolt11-decoder'
+import BOLT12Decoder, { type Invoice as BOLT12Invoice } from 'bolt12-decoder'
+import type { DecodedInvoice as Bolt11DecodedInvoice } from 'light-bolt11-decoder'
+
+export type InvoiceFormat = 'bolt11' | 'bolt12'
+
+export interface DecodedInvoiceResult {
+  format: InvoiceFormat
+  amount: number
+  description: string
+  paymentHash: string
+  payeePubKey: string | null
+  bolt11Raw: Bolt11DecodedInvoice | null
+}
+
+function isBolt12(invoice: string) {
+  return (
+    invoice.startsWith('lni1') || invoice.startsWith('lno1') || invoice.startsWith('lnr1')
+  )
+}
+
+function toSats(msats: string | number | undefined) {
+  const parsed = Number(msats)
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null
+  }
+
+  return Math.floor(parsed / 1000)
+}
+
+function decodeBolt11(invoice: string): DecodedInvoiceResult | null {
+  const decoded = bolt11.decode(invoice)
+
+  if (!decoded) {
+    return null
+  }
+
+  const amount = toSats(decoded.sections.find((section) => section.name === 'amount')?.value)
+  const description =
+    decoded.sections.find((section) => section.name === 'description')?.value ?? 'empty'
+  const paymentHash = decoded.sections.find((section) => section.name === 'payment_hash')?.value
+
+  if (amount === null || !paymentHash) {
+    return null
+  }
+
+  return {
+    format: 'bolt11',
+    amount,
+    description,
+    paymentHash,
+    payeePubKey: null,
+    bolt11Raw: decoded,
+  }
+}
+
+function decodeBolt12(invoice: string): DecodedInvoiceResult | null {
+  const decoded = BOLT12Decoder.decode(invoice)
+
+  if (decoded.type === 'offer') {
+    throw new Error(
+      'BOLT12 offers cannot be verified with a payment preimage. Use a BOLT12 invoice (lni1...).',
+    )
+  }
+
+  if (decoded.type === 'invoice_request') {
+    throw new Error(
+      'BOLT12 invoice requests cannot be verified with a payment preimage. Use a BOLT12 invoice (lni1...).',
+    )
+  }
+
+  const invoiceMessage = decoded as BOLT12Invoice
+  const amount = toSats(invoiceMessage.amount)
+
+  if (amount === null || !invoiceMessage.paymentHash) {
+    return null
+  }
+
+  return {
+    format: 'bolt12',
+    amount,
+    description: invoiceMessage.description ?? invoiceMessage.payerNote ?? 'empty',
+    paymentHash: invoiceMessage.paymentHash,
+    payeePubKey: invoiceMessage.nodeId ?? null,
+    bolt11Raw: null,
+  }
+}
+
+export function decodeInvoice(invoice: string): DecodedInvoiceResult | null {
+  const normalizedInvoice = invoice.trim().toLowerCase()
+
+  if (!normalizedInvoice) {
+    return null
+  }
+
+  if (isBolt12(normalizedInvoice)) {
+    return decodeBolt12(normalizedInvoice)
+  }
+
+  return decodeBolt11(normalizedInvoice)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/secp256k1": "^2.1.0",
         "@vee-validate/zod": "^4.14.7",
         "@vueuse/core": "^12.0.0",
+        "bolt12-decoder": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "light-bolt11-decoder": "^3.2.0",
@@ -26,7 +27,7 @@
       },
       "devDependencies": {
         "@iconify/vue": "^4.2.0",
-        "@nuxt/devtools": "*",
+        "@nuxt/devtools": "latest",
         "@nuxtjs/tailwindcss": "^6.12.2",
         "@types/jsdom": "^21.1.7",
         "@types/luxon": "^3.4.2",
@@ -104,6 +105,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -611,6 +613,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -634,6 +637,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1826,6 +1830,18 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/secp256k1": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
@@ -1952,7 +1968,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
       "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nuxt/cli/node_modules/giget": {
       "version": "3.1.2",
@@ -2660,6 +2677,7 @@
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.1.tgz",
       "integrity": "sha512-UjBFt72dnpc+83BV3OIbCT0YHLevJtgJCHpxMX0YRKWLDhhbcDdUse87GtsQBrjvOzK7WUNUYLDS/hQLYev5rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "c12": "^3.3.3",
         "consola": "^3.4.2",
@@ -3441,6 +3459,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5068,6 +5087,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5693,6 +5713,7 @@
       "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5786,6 +5807,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6481,6 +6503,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
       "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.27",
@@ -6751,6 +6774,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7252,6 +7276,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7295,6 +7325,44 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bolt12-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bolt12-decoder/-/bolt12-decoder-1.0.0.tgz",
+      "integrity": "sha512-G0nLHvRplv26RkW6sG/7BgWZNiJjVArCvpIarO64yiJcLwfoQMA713VU6QVtzcQoWvG55+bXKDXH+0iP/4zENA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.5.0",
+        "bech32": "^2.0.0",
+        "buffer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/bolt12-decoder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -7342,6 +7410,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7498,6 +7567,7 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9057,6 +9127,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -9215,6 +9286,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9275,6 +9347,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9348,6 +9421,7 @@
       "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "globals": "^13.24.0",
@@ -11144,6 +11218,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13548,6 +13623,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -13606,6 +13682,7 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.112.0.tgz",
       "integrity": "sha512-7rQ3QdJwobMQLMZwQaPuPYMEF2fDRZwf51lZ//V+bA37nejjKW5ifMHbbCwvA889Y4RLhT+/wLJpPRhAoBaZYw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.112.0"
       },
@@ -13956,6 +14033,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14406,6 +14484,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14673,6 +14752,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15332,6 +15412,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -16499,6 +16580,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16720,6 +16802,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16937,8 +17020,8 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17684,6 +17767,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -18288,6 +18372,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18552,6 +18637,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18565,6 +18651,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -18661,6 +18748,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -18741,6 +18829,7 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -18763,6 +18852,7 @@
       "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@volar/typescript": "2.4.15",
         "@vue/language-core": "2.2.12"
@@ -19090,6 +19180,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -19218,6 +19309,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@noble/secp256k1": "^2.1.0",
     "@vee-validate/zod": "^4.14.7",
     "@vueuse/core": "^12.0.0",
+    "bolt12-decoder": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "light-bolt11-decoder": "^3.2.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, watchEffect, ref } from 'vue'
 
-import bolt11 from 'light-bolt11-decoder'
+import { decodeInvoice } from '~/composables/invoice'
 // import { Duration } from 'luxon'
 
 import { Icon } from '@iconify/vue'
@@ -29,57 +29,54 @@ import Separator from '~/components/ui/separator/Separator.vue'
 
 const isPaid = ref(false)
 const isVerified = ref(false)
+const decodeError = ref('')
 
 const { form } = useForm()
 
 const payeePubKey = ref('')
 
 const decodedInvoice = computed(() => {
+  decodeError.value = ''
+
   try {
-    const decoded = bolt11.decode(form.invoice)
-
-    if (!decoded) {
-      return null
-    }
-
-    const amount = decoded.sections.find((section) => section.name === 'amount')?.value
-    const description =
-      decoded.sections.find((section) => section.name === 'description')?.value ?? 'empty'
-    const paymentHash =
-      decoded.sections.find((section) => section.name === 'payment_hash')?.value ?? ''
-
-    if (!amount) {
-      return null
-    }
-
-    return {
-      amount: Math.floor(Number(amount) / 1000),
-      description,
-      paymentHash,
-      decoded,
-    }
+    return decodeInvoice(form.invoice)
   } catch (error) {
-    console.error(error)
+    decodeError.value = error instanceof Error ? error.message : 'Invalid invoice'
     return null
   }
 })
 
 watchEffect(async () => {
+  isPaid.value = false
   isVerified.value = false
+  payeePubKey.value = ''
+
   if (decodedInvoice.value) {
     isPaid.value = await checkPaymentProof()
     isVerified.value = true
-    payeePubKey.value = (await getPubkeyFromSignature(decodedInvoice.value.decoded)) || ''
+
+    if (decodedInvoice.value.bolt11Raw) {
+      payeePubKey.value = (await getPubkeyFromSignature(decodedInvoice.value.bolt11Raw)) || ''
+      return
+    }
+
+    payeePubKey.value = decodedInvoice.value.payeePubKey ?? ''
   }
 })
 
 async function checkPaymentProof() {
-  const preimage = form.preimage
-  if (preimage === null) {
+  if (!decodedInvoice.value) {
     return false
   }
+
+  const preimage = form.preimage?.trim()
+
+  if (!preimage || preimage.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(preimage)) {
+    return false
+  }
+
   const preimageBytes = new Uint8Array(
-    preimage!.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
+    preimage.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
   )
 
   // Calculate SHA-256 hash using Web Crypto API
@@ -106,7 +103,7 @@ function formatLong(text: string) {
         <CardDescription class="text-xs">
           <p>
             The provided preimage cryptographically proves that the specified invoice has been
-            successfully paid.
+            successfully paid. Supports both BOLT11 and BOLT12 invoices.
           </p>
           <p>
             Learn more
@@ -123,9 +120,10 @@ function formatLong(text: string) {
         <Separator />
         <div class="font-medium mb-2 mt-5">Invoice:</div>
         <div class="flex w-full items-center">
-          <Input id="invoice" type="text" placeholder="bolt11" v-model="form.invoice" />
+          <Input id="invoice" type="text" placeholder="bolt11 or bolt12 invoice" v-model="form.invoice" />
           <CopyButton title="invoice" :value="form.invoice" />
         </div>
+        <p v-if="decodeError" class="text-destructive text-sm mt-2">{{ decodeError }}</p>
         <div class="font-medium mb-2 mt-5">Payment Proof:</div>
         <div class="flex w-full items-center">
           <Input id="preimage" type="text" placeholder="preimage" v-model="form.preimage" />
@@ -142,6 +140,10 @@ function formatLong(text: string) {
               </TableRow>
             </TableHeader>
             <TableBody>
+              <TableRow>
+                <TableCell class="font-medium"> Format </TableCell>
+                <TableCell class="text-right uppercase"> {{ decodedInvoice.format }} </TableCell>
+              </TableRow>
               <TableRow>
                 <TableCell class="font-medium"> Amount </TableCell>
                 <TableCell class="text-right">


### PR DESCRIPTION
## Summary
- add a new `decodeInvoice` composable that supports both BOLT11 and BOLT12 invoices
- reject BOLT12 offers/invoice-requests with explicit UI-facing guidance to provide an `lni1` invoice
- show invoice format in the details table and keep preimage verification flow compatible with both formats
- add unit tests for BOLT11 decode, BOLT12 decode, and BOLT12 non-invoice rejection paths
- add `bolt12-decoder` dependency and update footer credits

## Testing
- `npm run test:unit -- --run`
- `npm run build`

Fixes #7
